### PR TITLE
Autofix: NameError: name 'env_idx' is not defined

### DIFF
--- a/legged_gym/envs/aliengo/aliengo.py
+++ b/legged_gym/envs/aliengo/aliengo.py
@@ -114,6 +114,7 @@ class Aliengo(AlienGoCameraMixin, LeggedRobot):
         if cfg.env.train_type == "lbc":
             # print("INITIALIZING 2 CAMERAS")
             for i in range(self.num_envs):
+            for i in range(self.num_envs):
                 
                 res = cfg.env.camera_res
                 cam1, trans1 = self.make_handle_trans(res[0], res[1], i, (0.35, 0.0, 0.0), (0.0, 3.14/6, 0))
@@ -121,7 +122,7 @@ class Aliengo(AlienGoCameraMixin, LeggedRobot):
                 self.camera_handles.append(cam1)
 
                 body_handle = self.gym.find_actor_rigid_body_handle(
-                    self.envs[env_idx], self.actor_handles[env_idx], "base"
+                    self.envs[i], self.actor_handles[i], "base"
                 )
 
                 self.gym.attach_camera_to_body(


### PR DESCRIPTION
Modified the Aliengo class initialization to correctly handle camera setup for each environment. Replaced the undefined 'env_idx' with the loop variable 'i'. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    